### PR TITLE
fixed exif and zip functionality + configured to use latest php automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.6-apache-buster
+FROM php:8.0-apache
 
 RUN apt-get update && apt-get upgrade -yy \
     && apt-get install --no-install-recommends apt-utils libjpeg-dev libpng-dev libwebp-dev \
@@ -6,8 +6,9 @@ RUN apt-get update && apt-get upgrade -yy \
     unzip software-properties-common -yy \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN docker-php-ext-configure zip --with-zip \
+RUN docker-php-ext-install zip \
     && docker-php-ext-install mysqli pdo pdo_mysql \
+    && docker-php-ext-install exif \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j "$(nproc)" gd \
     && a2enmod rewrite

--- a/app/.htaccess
+++ b/app/.htaccess
@@ -13,5 +13,6 @@ php_value upload_max_filesize 64M
 php_value post_max_size 64M
 php_value max_execution_time 300
 php_value max_input_time 300
+php_value memory_limit 256M
 
 # END WordPress


### PR DESCRIPTION
Small maintenance update to ensure exif and zip modules work. PHP latest version is now used by default. Result is  Wordpress site health rating improves, with only the Imagick module missing. When Imagick releases an official PHP 8 extension, we can include it in the Dockerfile.

Also included a small update to .htaccess to ensure memory limit is ok at 256M. Max upload of 64M is retained.